### PR TITLE
[membership] fix peers change failed when cluster- estart in joint status

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -33,6 +33,9 @@
 #include "braft/node_manager.h"
 #include "braft/snapshot_executor.h"
 #include "braft/errno.pb.h"
+#include "braft/sync_point.h"
+#include "butil/logging.h"
+
 
 namespace braft {
 
@@ -1585,9 +1588,9 @@ void NodeImpl::pre_vote(std::unique_lock<raft_mutex_t>* lck, bool triggered) {
                         " configuration is possibly out of date";
         return;
     }
-    if (!_conf.contains(_server_id)) {
+    if (_conf.empty()) {
         LOG(WARNING) << "node " << _group_id << ':' << _server_id
-                     << " can't do pre_vote as it is not in " << _conf.conf;
+                     << " can't do pre_vote as conf is emtpy";
         return;
     }
 
@@ -1644,9 +1647,9 @@ void NodeImpl::elect_self(std::unique_lock<raft_mutex_t>* lck,
                           bool old_leader_stepped_down) {
     LOG(INFO) << "node " << _group_id << ":" << _server_id
               << " term " << _current_term << " start vote and grant vote self";
-    if (!_conf.contains(_server_id)) {
+    if (_conf.empty()) {
         LOG(WARNING) << "node " << _group_id << ':' << _server_id
-                     << " can't do elect_self as it is not in " << _conf.conf;
+                     << " can't do elect_self as _conf is empty";
         return;
     }
     // cancel follower election timer
@@ -2108,7 +2111,6 @@ int NodeImpl::handle_pre_vote_request(const RequestVoteRequest* request,
         LogId last_log_id = _log_manager->last_log_id(true);
         lck.lock();
         // pre_vote not need ABA check after unlock&lock
-
         int64_t votable_time = _follower_lease.votable_time_from_now();
         bool grantable = (LogId(request->last_log_index(), request->last_log_term())
                         >= last_log_id);
@@ -3267,6 +3269,7 @@ void NodeImpl::ConfigurationCtx::next_stage() {
         // implementation.
     case STAGE_JOINT:
         _stage = STAGE_STABLE;
+        TEST_SYNC_POINT_CALLBACK("NodeImpl::ConfigurationCtx:StableStage:BeforeApplyConfiguration", _node);
         return _node->unsafe_apply_configuration(
                     Configuration(_new_peers), NULL, false);
     case STAGE_STABLE:

--- a/src/braft/sync_point.cpp
+++ b/src/braft/sync_point.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2017 Baidu.com, Inc. All Rights Reserved
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "sync_point.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <fcntl.h>
+
+#ifndef NDEBUG
+namespace braft {
+
+struct SyncPoint::Data {
+  Data() : enabled_(false) {}
+  // Enable proper deletion by subclasses
+  virtual ~Data() {}
+  // successor/predecessor map loaded from LoadDependency
+  std::unordered_map<std::string, std::vector<std::string>> successors_;
+  std::unordered_map<std::string, std::vector<std::string>> predecessors_;
+  std::unordered_map<std::string, std::function<void(void *)>> callbacks_;
+  std::unordered_map<std::string, std::vector<std::string>> markers_;
+  std::unordered_map<std::string, std::thread::id> marked_thread_id_;
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  // sync points that have been passed through
+  std::unordered_set<std::string> cleared_points_;
+  std::atomic<bool> enabled_;
+  int num_callbacks_running_ = 0;
+
+  void LoadDependency(const std::vector<SyncPointPair> &dependencies);
+  void LoadDependencyAndMarkers(const std::vector<SyncPointPair> &dependencies,
+                                const std::vector<SyncPointPair> &markers);
+  bool PredecessorsAllCleared(const std::string &point);
+  void SetCallBack(const std::string &point,
+                   const std::function<void(void *)> &callback) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    callbacks_[point] = callback;
+  }
+
+  void ClearCallBack(const std::string &point);
+  void ClearAllCallBacks();
+  void EnableProcessing() { enabled_ = true; }
+  void DisableProcessing() { enabled_ = false; }
+  void ClearTrace() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cleared_points_.clear();
+  }
+  bool DisabledByMarker(const std::string &point, std::thread::id thread_id) {
+    auto marked_point_iter = marked_thread_id_.find(point);
+    return marked_point_iter != marked_thread_id_.end() &&
+           thread_id != marked_point_iter->second;
+  }
+  void Process(const std::string &point, void *cb_arg);
+};
+
+SyncPoint *SyncPoint::GetInstance() {
+  static SyncPoint sync_point;
+  return &sync_point;
+}
+
+SyncPoint::SyncPoint() : impl_(new Data) {}
+
+SyncPoint::~SyncPoint() { delete impl_; }
+
+void SyncPoint::LoadDependency(const std::vector<SyncPointPair> &dependencies) {
+  impl_->LoadDependency(dependencies);
+}
+
+void SyncPoint::LoadDependencyAndMarkers(
+    const std::vector<SyncPointPair> &dependencies,
+    const std::vector<SyncPointPair> &markers) {
+  impl_->LoadDependencyAndMarkers(dependencies, markers);
+}
+
+void SyncPoint::SetCallBack(const std::string &point,
+                            const std::function<void(void *)> &callback) {
+  impl_->SetCallBack(point, callback);
+}
+
+void SyncPoint::ClearCallBack(const std::string &point) {
+  impl_->ClearCallBack(point);
+}
+
+void SyncPoint::ClearAllCallBacks() { impl_->ClearAllCallBacks(); }
+
+void SyncPoint::EnableProcessing() { impl_->EnableProcessing(); }
+
+void SyncPoint::DisableProcessing() { impl_->DisableProcessing(); }
+
+void SyncPoint::ClearTrace() { impl_->ClearTrace(); }
+
+void SyncPoint::Process(const std::string &point, void *cb_arg) {
+  impl_->Process(point, cb_arg);
+}
+
+void SyncPoint::Data::LoadDependency(
+    const std::vector<SyncPointPair> &dependencies) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  successors_.clear();
+  predecessors_.clear();
+  cleared_points_.clear();
+  for (const auto &dependency : dependencies) {
+    successors_[dependency.predecessor].push_back(dependency.successor);
+    predecessors_[dependency.successor].push_back(dependency.predecessor);
+  }
+  cv_.notify_all();
+}
+
+void SyncPoint::Data::LoadDependencyAndMarkers(
+    const std::vector<SyncPointPair> &dependencies,
+    const std::vector<SyncPointPair> &markers) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  successors_.clear();
+  predecessors_.clear();
+  cleared_points_.clear();
+  markers_.clear();
+  marked_thread_id_.clear();
+  for (const auto &dependency : dependencies) {
+    successors_[dependency.predecessor].push_back(dependency.successor);
+    predecessors_[dependency.successor].push_back(dependency.predecessor);
+  }
+  for (const auto &marker : markers) {
+    successors_[marker.predecessor].push_back(marker.successor);
+    predecessors_[marker.successor].push_back(marker.predecessor);
+    markers_[marker.predecessor].push_back(marker.successor);
+  }
+  cv_.notify_all();
+}
+
+bool SyncPoint::Data::PredecessorsAllCleared(const std::string &point) {
+  for (const auto &pred : predecessors_[point]) {
+    if (cleared_points_.count(pred) == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void SyncPoint::Data::ClearCallBack(const std::string &point) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (num_callbacks_running_ > 0) {
+    cv_.wait(lock);
+  }
+  callbacks_.erase(point);
+}
+
+void SyncPoint::Data::ClearAllCallBacks() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (num_callbacks_running_ > 0) {
+    cv_.wait(lock);
+  }
+  callbacks_.clear();
+}
+
+void SyncPoint::Data::Process(const std::string &point, void *cb_arg) {
+  if (!enabled_) {
+    return;
+  }
+
+  std::unique_lock<std::mutex> lock(mutex_);
+  auto thread_id = std::this_thread::get_id();
+
+  auto marker_iter = markers_.find(point);
+  if (marker_iter != markers_.end()) {
+    for (auto &marked_point : marker_iter->second) {
+      marked_thread_id_.emplace(marked_point, thread_id);
+    }
+  }
+
+  if (DisabledByMarker(point, thread_id)) {
+    return;
+  }
+
+  while (!PredecessorsAllCleared(point)) {
+    cv_.wait(lock);
+    if (DisabledByMarker(point, thread_id)) {
+      return;
+    }
+  }
+
+  auto callback_pair = callbacks_.find(point);
+  if (callback_pair != callbacks_.end()) {
+    num_callbacks_running_++;
+    mutex_.unlock();
+    callback_pair->second(cb_arg);
+    mutex_.lock();
+    num_callbacks_running_--;
+  }
+  cleared_points_.insert(point);
+  cv_.notify_all();
+}
+} // namespace braft
+#endif // NDEBUG

--- a/src/braft/sync_point.h
+++ b/src/braft/sync_point.h
@@ -1,0 +1,154 @@
+// Copyright (c) 2017 Baidu.com, Inc. All Rights Reserved
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+#pragma once
+
+#include <assert.h>
+
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef NDEBUG
+#define TEST_SYNC_POINT(x)
+#define TEST_IDX_SYNC_POINT(x, index)
+#define TEST_SYNC_POINT_CALLBACK(x, y)
+#define INIT_SYNC_POINT_SINGLETONS()
+#else
+
+namespace braft {
+
+// This class provides facility to reproduce race conditions deterministically
+// in unit tests.
+// Developer could specify sync points in the codebase via TEST_SYNC_POINT.
+// Each sync point represents a position in the execution stream of a thread.
+// In the unit test, 'Happens After' relationship among sync points could be
+// setup via SyncPoint::LoadDependency, to reproduce a desired interleave of
+// threads execution.
+
+class SyncPoint {
+ public:
+  static SyncPoint* GetInstance();
+
+  SyncPoint(const SyncPoint&) = delete;
+  SyncPoint& operator=(const SyncPoint&) = delete;
+  ~SyncPoint();
+
+  struct SyncPointPair {
+    std::string predecessor;
+    std::string successor;
+  };
+
+  // call once at the beginning of a test to setup the dependency between
+  // sync points. Specifically, execution will not be allowed to proceed past
+  // each successor until execution has reached the corresponding predecessor,
+  // in any thread.
+  void LoadDependency(const std::vector<SyncPointPair>& dependencies);
+
+  // call once at the beginning of a test to setup the dependency between
+  // sync points and setup markers indicating the successor is only enabled
+  // when it is processed on the same thread as the predecessor.
+  // When adding a marker, it implicitly adds a dependency for the marker pair.
+  void LoadDependencyAndMarkers(const std::vector<SyncPointPair>& dependencies,
+                                const std::vector<SyncPointPair>& markers);
+
+  // The argument to the callback is passed through from
+  // TEST_SYNC_POINT_CALLBACK(); nullptr if TEST_SYNC_POINT or
+  // TEST_IDX_SYNC_POINT was used.
+  void SetCallBack(const std::string& point,
+                   const std::function<void(void*)>& callback);
+
+  // Clear callback function by point
+  void ClearCallBack(const std::string& point);
+
+  // Clear all call back functions.
+  void ClearAllCallBacks();
+
+  // enable sync point processing (disabled on startup)
+  void EnableProcessing();
+
+  // disable sync point processing
+  void DisableProcessing();
+
+  // remove the execution trace of all sync points
+  void ClearTrace();
+
+  // triggered by TEST_SYNC_POINT, blocking execution until all predecessors
+  // are executed.
+  // And/or call registered callback function, with argument `cb_arg`
+  void Process(const std::string& point, void* cb_arg = nullptr);
+
+  // template gets length of const string at compile time,
+  //  avoiding strlen() at runtime
+  template <size_t kLen>
+  void Process(const char (&point)[kLen], void* cb_arg = nullptr) {
+    static_assert(kLen > 0, "Must not be empty");
+    assert(point[kLen - 1] == '\0');
+    Process(std::string(point, kLen - 1), cb_arg);
+  }
+
+  // TODO: it might be useful to provide a function that blocks until all
+  // sync points are cleared.
+
+  // We want this to be public so we can
+  // subclass the implementation
+  struct Data;
+
+ private:
+  // Singleton
+  SyncPoint();
+  Data* impl_;
+};
+
+// Sets up sync points to mock direct IO instead of actually issuing direct IO
+// to the file system.
+void SetupSyncPointsToMockDirectIO();
+}  // namespace braft
+
+// Use TEST_SYNC_POINT to specify sync points inside code base.
+// Sync points can have happens-after dependency on other sync points,
+// configured at runtime via SyncPoint::LoadDependency. This could be
+// utilized to re-produce race conditions between threads.
+// See TransactionLogIteratorRace in db_test.cc for an example use case.
+// TEST_SYNC_POINT is no op in release build.
+#define TEST_SYNC_POINT(x) \
+  braft::SyncPoint::GetInstance()->Process(x)
+#define TEST_IDX_SYNC_POINT(x, index)                      \
+  braft::SyncPoint::GetInstance()->Process(x + \
+                                                       std::to_string(index))
+#define TEST_SYNC_POINT_CALLBACK(x, y) \
+  braft::SyncPoint::GetInstance()->Process(x, y)
+#define INIT_SYNC_POINT_SINGLETONS() \
+  (void)braft::SyncPoint::GetInstance();
+#endif  // NDEBUG
+
+// Callback sync point for any read IO errors that should be ignored by
+// the fault injection framework
+// Disable in release mode
+#ifdef NDEBUG
+#define IGNORE_STATUS_IF_ERROR(_status_)
+#else
+#define IGNORE_STATUS_IF_ERROR(_status_)            \
+  {                                                 \
+    if (!_status_.ok()) {                           \
+      TEST_SYNC_POINT("FaultInjectionIgnoreError"); \
+    }                                               \
+  }
+#endif  // NDEBUG

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -4,11 +4,13 @@
 // Author: WangYao (fisherman), wangyao02@baidu.com
 // Date: 2015/10/08 17:00:05
 
+#include <algorithm>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <braft/sync_point.h>
 #include <butil/logging.h>
 #include <butil/files/file_path.h>
 #include <butil/file_util.h>
@@ -16,6 +18,7 @@
 #include <brpc/closure_guard.h>
 #include <bthread/bthread.h>
 #include <bthread/countdown_event.h>
+#include <vector>
 #include "../test/util.h"
 
 namespace braft {
@@ -2754,6 +2757,121 @@ TEST_P(NodeTest, change_peers_steps_down_in_joint_consensus) {
         --wait_count;
     }
     ASSERT_TRUE(!leader->_impl->_conf_ctx.is_busy());
+}
+
+// A test case used to reboot cluster between join stage and stable stage,
+// during this time the new configuration has not replicated to C_{new} peers,
+// but replicated to the peers not in C_{new} that is diff(C_{old,new},
+// C_{new}).
+TEST_P(NodeTest, change_peers_restart_cluster_before_stable_stage) {
+    // This case do the folling steps:
+    // 1. start a five nodes cluster (peer0,1,2,3,4).
+    // 2. remove 3 nodes (form {peer0,1,2,3,4} to {peer3,4}).
+    // 3. stop {peer3,4} before leader start to replicate new configuration.
+    // 4. reboot cluster, and check memebership change can be continued to
+    // complete successfuly.
+    std::vector<braft::PeerId> all_peers;
+    braft::PeerId peer0("127.0.0.1:5006");
+    braft::PeerId peer1("127.0.0.1:5007");
+    braft::PeerId peer2("127.0.0.1:5008");
+    braft::PeerId peer3("127.0.0.1:5009");
+    braft::PeerId peer4("127.0.0.1:5010");
+    all_peers = {peer0, peer1, peer2, peer3, peer4};
+
+    Cluster cluster("unittest", all_peers);
+    for (const auto &peer : all_peers) {
+        ASSERT_EQ(cluster.start(peer.addr), 0);
+    }
+    LOG(INFO) << "started five nodes cluster";
+    cluster.wait_leader();
+    braft::Node* leader = cluster.leader();
+
+    // Transfer leadership to peer0 because it not in `keep_peers`.
+    ASSERT_EQ(0, leader->transfer_leadership_to(peer0));
+    cluster.wait_leader();
+    leader = cluster.leader();
+    ASSERT_EQ(leader->leader_id(), peer0);
+
+    bthread::CountdownEvent cond(10);
+    for (int i = 0; i < 10; i++) {
+        butil::IOBuf data;
+        char data_buf[128];
+        snprintf(data_buf, sizeof(data_buf), "hello: %d", i + 1);
+        data.append(data_buf);
+        braft::Task task;
+        task.data = &data;
+        task.done = NEW_APPLYCLOSURE(&cond, 0);
+        leader->apply(task);
+    }
+    cond.wait();
+
+    // Start to change peers from 5 to 2, just keep peer3 and peer4.
+    //
+    // After joint configuration (`C_old `and `C_new`) has committed
+    // and before applying stable configuration (`Cnew`), we stop peer3 and peer4,
+    // so `Cnew` can not be committed. Then restart cluster to continue membership
+    // change process.
+    std::vector<braft::PeerId> keep_peers = {peer3, peer4};
+    SyncPoint::GetInstance()->SetCallBack(
+        "NodeImpl::ConfigurationCtx:StableStage:BeforeApplyConfiguration",
+        [&cluster, &keep_peers](void *) -> void {
+          for (const auto &peer : keep_peers) {
+            ASSERT_EQ(cluster.stop(peer.addr), 0);
+          }
+        });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    braft::SynchronizedClosure done;
+    Configuration conf(keep_peers);
+    leader->change_peers(conf, &done);
+    done.wait();
+    ASSERT_EQ(EPERM, done.status().error_code());
+    // Current leader has received Cnew.
+    ASSERT_TRUE(leader->_impl->_conf.stable());
+    
+    // Restart cluster
+    cluster.stop_all();
+    SyncPoint::GetInstance()->DisableProcessing();
+
+    Cluster new_cluster("unittest", keep_peers);
+    for (const auto &peer : all_peers) {
+        ASSERT_EQ(cluster.start(peer.addr), 0);
+    }
+    LOG(INFO) << "restarted five nodes cluste";
+
+    // Waiting leader to be elected from `keep_peers` eventually.
+    int wait_count = 10;
+    while (wait_count > 0) {
+        cluster.wait_leader();
+        leader = cluster.leader();
+        if (std::find(keep_peers.begin(), keep_peers.end(),
+                      leader->leader_id()) != keep_peers.end()) {
+            break;
+        }
+        usleep(5 * 1000);
+        --wait_count;
+    }
+    ASSERT_GT(wait_count, 0);
+    cluster.check_node_status();
+    
+    // Now we can remove unused nodes safely.
+    for (const auto &peer : all_peers) {
+        if (std::find(keep_peers.begin(), keep_peers.end(), 
+        peer) == keep_peers.end()) {
+            ASSERT_EQ(cluster.stop(peer.addr), 0);
+        }
+    }
+
+    leader = cluster.leader();
+    ASSERT_TRUE(leader->_impl->_conf.stable());
+    // Check the new configuration must be the same as `keep_peers`.
+    std::vector<PeerId> new_peers;
+    leader->list_peers(&new_peers);
+    for (const auto &peer : new_peers) {
+        ASSERT_TRUE(std::find(keep_peers.begin(), keep_peers.end(), peer) !=
+                    keep_peers.end());
+    }
+    cluster.ensure_same();
 }
 
 struct ChangeArg {

--- a/test/util.h
+++ b/test/util.h
@@ -264,9 +264,8 @@ public:
                             butil::endpoint2str(listen_addr).c_str());
         butil::string_printf(&options.snapshot_uri, "local://./data/%s/snapshot",
                             butil::endpoint2str(listen_addr).c_str());
-        
-        scoped_refptr<braft::SnapshotThrottle> tst(_throttle);
-        options.snapshot_throttle = &tst;
+
+        options.snapshot_throttle = &_throttle;
 
         options.catchup_margin = 2;
         
@@ -516,7 +515,7 @@ private:
     int32_t _election_timeout_ms;
     int32_t _max_clock_drift_ms;
     raft_mutex_t _mutex;
-    braft::SnapshotThrottle* _throttle;
+    scoped_refptr<braft::SnapshotThrottle> _throttle;
 };
 
 #endif // ~PUBLIC_RAFT_TEST_UTIL_H


### PR DESCRIPTION
details: https://github.com/baidu/braft/pull/407

## issue
`change_peers` 过程中继续重启，可能导致无法恢复。
bad case (*from braft wechat group*)：
1. 启动 5 个节点的 cluster $(A,B,C,D,E)$
2. `leader` 在 $(A,B,C)$ 中, 开始节点变更，从集群中删除 $(A,B,C)$ , 仅保留 $(D,E)$, 
    即 $C_{old} = (A,B,C,D,E)$ , $C_{new} = (D,E)$
3. 当 `leader` 完成第一阶段日志 $C_{old,new}$ 提交 后，在 `leader` 开始第二阶段的日志($C_{new}$）提交前，这时 $(D,E)$ 节点下线，导致 $C_{new}$ 无法被提交(其大多数节点失效），而 $C_{new}$ 日志可能会被复制到 $(A,B,C)$ 中。 
4. 所有节点重启，此时由于 $(A,B,C)$ 中的最新日志为 $C_{new}$， 都不属于该配置 ，无法完成选举（ 按照 braft 现在实现， PreVote 无法发起）； 而 $(D,E)$ 节点中最新日志为 $C_{old,new}$，依然无法完成选举, 因为其相较于 $(A,B,C)$ 节点日志落后，并且 $majority(C_{old,new}) = 3 > 2 $。 所以整个集群无法选举出 `leader`，继续后续流程。

## cause
1. braft 实现中，在节点变更的第二阶段，会将 $C_{new}$ 作为日志继续给当前的所有 follower 发送，即使是当前 $C_{new}$ 中不包含的节点。如果能够在提交第二阶段日志时， 不复制 $C_{new}$ 日志到不属于其配置的节点（$diff(C_{new,old}, C_{new})$）, 那么在集群恢复后，这些节点由于不持有最新的 $C_new$, 故而可以重新发起选举，完成后续流程。 
**安全性**
a. 如果集群重启前， $C_{new}$  已经被成功提交，那么不属于 $C_{new}$  的节点由于持有第一阶段的配置 $C_{old, new}$, 无法获得来自  $C_{new}$ 节点中大多数的投票，故而无法选举 leader （预期的行为）。 而 $C_new$ 由于已经被提交，所以 $C_{new}$ 中的节点能够正常选举 leader， 因此完成了 `membership change` 流程， 集群恢复正常。
b.  如果集群重启前， $C_{new}$  未被成功提交，那么属于 $C_{new,old}$ 中的节点是可以从 $C_{new}$ 中获得大多数投票，从而完成选举。 如果选举的 leader 包含 $C_{new}$ , 那么第一次日志提交后（ flush configuration 等），即可完成 membership change；如果选举的 leader  只包含 $C_{new，old}$， 重新进入 `joint stage`， 并且接着开始复制 $C_{new}$ 并完成 `membership change` 的 stable 状态。

2. braft 实现中，如果节点 id 不属于在当前 conf，不允许节点发起选举。如果放松这个限制的话，也可以避免上述问题。
**安全性**
a. 如果不属于 conf 的节点可以发起投票，并且当选 leader，那么说明该节点包含当前 conf 中最新的日志，并且获得 conf 中大多数人的同意（自己的投票不会被计数），满足 leader 的安全性，见 [raft §5.4.3 Safety argument](https://raft.github.io/raft.pdf)。此时该节点可以看作是一个代理节点，负责转发 raft 请求，但是不参与 raft 的投票和 commit 日志的决策，不影响 raft 的安全性。
对于本例中，重启后不属于 $C_{new}$ 的节点发起投票，并且能够获得来自 $C_{new}$ 的大多数投票，当该 leader 完成第一次日志复制后（ flush configuration）， $C_{new}$ 日志会被提交到 $C_{new}$ 节点中（想当于继续完成了重启前未完成的 membership change 的第二阶段）。 而该 leader 会在完成 stable 阶段完成 step down，不参与后续流程。而此时 $C_{new}$ 节点中也已经持有最新的日志，其他无关节点无法继续参与 $C_{new}$ 的后续事务（因为不包含最新日志）。所以也是安全的。


## solutions

1. 从目前 braft 的实现来看， 如果采取第一种的话，比较难以实现：
a. 如何控制在第一阶段的 $C_{old,new}$ 提交后，$C_{new}$ 不复制到其他节点。可以采取的方案可以为 `stop_replicator`, 将节点设置为 `readonly` 或者发送前日志/接受日志时进行判断等等，这个会增加较多的代码逻辑。
b. 如果当前 leader 不在 $C_{new}$ 中，很难做到不复制 $C_{new}$ 日志，因为  `AppendEntries` 需要从 `LogManager` 中获得新的日志进行复制, 这两者存在一定的矛盾，代码逻辑不好做修改。
2. **所以本 PR 采取第二种方案，放松可以参与选举节点的限制（不在最新的 configuration 的节点依然可以发起选举)**
由于当前的 braft 中没有注入错误故障的模块，在构造一些比较复杂的用例时，无法准确控制错误发生的时机，所以引入了 `SyncPoint` 模块 (copy from rocksdb)，提供回调机制来控制节点的行为。
使用方法：
``` c++
// set sync or callback at specific point identified by name.
TEST_SYNC_POINT/CALL_BACK(name, args)
// register call back function, it will be triggerd when code 
// reach the sync point with the same name.
SyncPoint::GetInstance()->SetCallBack(name, callback);
```

## test plan
```NodeTest.change_peers_restart_cluster_before_stable_stage```
模拟了上述 bad case 的用例。
在该修改前，测试会在重启节点之后一直保持无法选主状态，直到超时。
本修改之后，符合预期行为。
