### PR TITLE
[log] optimize get term

### DIFF
--- a/src/braft/log_manager.cpp
+++ b/src/braft/log_manager.cpp
@@ -132,7 +132,7 @@ void LogManager::clear_memory_logs(const LogId& id) {
             while (!_logs_in_memory.empty() 
                     && nentries < ARRAY_SIZE(entries_to_clear)) {
                 LogEntry* entry = _logs_in_memory.front();
-                if (entry->id > id) {
+                if (entry->id >= id) {
                     break;
                 }
                 entries_to_clear[nentries++] = entry;

--- a/src/braft/log_manager.h
+++ b/src/braft/log_manager.h
@@ -184,7 +184,7 @@ friend class AppendBatcher;
 
     void unsafe_truncate_suffix(const int64_t last_index_kept);
 
-    // Clear the logs in memory whose id <= the given |id|
+    // Clear the logs in memory whose id < the given |id|
     void clear_memory_logs(const LogId& id);
 
     int64_t unsafe_get_term(const int64_t index);


### PR DESCRIPTION
pick: https://github.com/baidu/braft/pull/438

leader 上 _logs_in_memory 中缓存的 LogEntry 会在 apply 完成且写到盘上后被清理掉。
leader 在 append_entries rpc 中需要获取 prev_log_term。
如果请求的并发比较小，发送新Log时，前一个LogEntry 很有可能已经从缓存清理掉了，prev_log_term 只能从 LogStorage 获取。（场景： 一个server上，node 数量特别多，但是单个node qps 比较小，能观察到 bvar raft_read_term_from_storage_second 很高）
这个 pr 在 clear_memory_logs 时多保留 log，使得上面场景总能通过缓存查询到 prev_log_term。
如果长时间不写，最后这个保留的 log 会在打快照的时候被清理掉。
